### PR TITLE
remove bracket in example with forgotten bracket

### DIFF
--- a/chapter-04.tex
+++ b/chapter-04.tex
@@ -696,7 +696,7 @@ Lisp. Таким образом, \lstinline{EQ} может считать два
 
 \begin{myverb}
 (defun foo ()
-  (if (test)
+  (if (test
     (do-one-thing)
     (do-another-thing))))
 \end{myverb}
@@ -706,7 +706,7 @@ Lisp. Таким образом, \lstinline{EQ} может считать два
 
 \begin{myverb}
 (defun foo ()
-  (if (test)
+  (if (test
        (do-one-thing)
        (do-another-thing))))
 \end{myverb}


### PR DESCRIPTION
"Теперь предположим, что вы случайно не поставили закрывающую скобку после
\lstinline{test}."